### PR TITLE
Velocity tools support & nested context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-tools</artifactId>
             <version>2.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
             
 

--- a/src/main/java/at/molindo/notify/util/VelocityUtils.java
+++ b/src/main/java/at/molindo/notify/util/VelocityUtils.java
@@ -22,6 +22,7 @@ import java.io.StringWriter;
 
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
+import org.apache.velocity.context.Context;
 import org.apache.velocity.exception.MethodInvocationException;
 import org.apache.velocity.exception.ParseErrorException;
 import org.apache.velocity.exception.ResourceNotFoundException;
@@ -58,9 +59,13 @@ public class VelocityUtils {
 	}
 
 	public static String merge(Template template, IParams params) throws RenderException {
+		return merge(template, params, null);
+	}
+
+	public static String merge(Template template, IParams params, Context nestedContext) throws RenderException {
 		try {
 			StringWriter writer = new StringWriter();
-			template.merge(new VelocityContext(params.newMap()), writer);
+			template.merge(new VelocityContext(params.newMap(), nestedContext), writer);
 			return writer.toString();
 		} catch (ResourceNotFoundException e) {
 			throw new RenderException("failed to render template " + template, e);


### PR DESCRIPTION
Just added a dependency for velocity-tools to make use of some more advanced velocity features. In this case it's the html escaper that allows to write e.g. $esc.html($new.newsArticle.teaser) in templates.
Also added a util-method to support nested velocity contexts - necessary to use the html escaper.
